### PR TITLE
Fix spelling errors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/src/problems/common.rs
+++ b/src/problems/common.rs
@@ -1382,7 +1382,7 @@ impl Display for UnsupportedDebhelperCompatLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Request debhlper compat level {} lower than supported {}",
+            "Request debhelper compat level {} lower than supported {}",
             self.requested, self.oldest_supported
         )
     }

--- a/src/sbuild.rs
+++ b/src/sbuild.rs
@@ -687,7 +687,7 @@ pub fn strip_build_tail<'a>(
 
     let mut interesting_lines: &'_ [&'a str] = lines;
 
-    // Strip off unuseful tail
+    // Strip off useless tail
     for (i, line) in lines.enumerate_tail_forward(look_back) {
         if line.starts_with("Build finished at ") {
             interesting_lines = &lines[..i];


### PR DESCRIPTION
Fix spelling errors
Used config files:
    1: .codespellrc

-------8<-------
SUMMARY:
debhlper      1
socio-economic1
unuseful      1
