### PR TITLE
Improve performance and quality

### DIFF
--- a/src/bin/analyze-build-log.rs
+++ b/src/bin/analyze-build-log.rs
@@ -29,7 +29,7 @@ fn as_json(m: Option<&dyn Match>, problem: Option<&dyn Problem>) -> serde_json::
         );
         ret.insert(
             "line".to_string(),
-            serde_json::Value::String(m.line().clone()),
+            serde_json::Value::String(m.line().to_string()),
         );
         ret.insert(
             "origin".to_string(),

--- a/src/bin/analyze-sbuild-log.rs
+++ b/src/bin/analyze-sbuild-log.rs
@@ -32,7 +32,7 @@ fn as_json(m: Option<&dyn Match>, problem: Option<&dyn Problem>) -> serde_json::
         );
         ret.insert(
             "line".to_string(),
-            serde_json::Value::String(m.line().clone()),
+            serde_json::Value::String(m.line().to_string()),
         );
         ret.insert(
             "origin".to_string(),

--- a/src/bin/chatgpt-analyze-log.rs
+++ b/src/bin/chatgpt-analyze-log.rs
@@ -37,7 +37,12 @@ fn main() {
         lines.iter().map(|l| l.as_str()).collect::<Vec<_>>(),
     ));
 
-    if let Some(m) = m {
-        log::info!("match: {}", m);
+    match m {
+        Ok(Some(m)) => log::info!("match: {}", m),
+        Ok(None) => log::info!("No match found"),
+        Err(e) => {
+            log::error!("Failed to analyze log: {}", e);
+            std::process::exit(1);
+        }
     }
 }

--- a/src/brz.rs
+++ b/src/brz.rs
@@ -29,11 +29,12 @@ pub fn find_brz_build_error(lines: Vec<&str>) -> Option<(Option<Box<dyn Problem>
     for (i, line) in lines.enumerate_backward(None) {
         if let Some(suffix) = line.strip_prefix("brz: ERROR: ") {
             let mut rest = vec![suffix.to_string()];
-            for n in lines[i + 1..].iter() {
-                if n.starts_with(" ") {
-                    rest.push(n.to_string());
-                }
-            }
+            rest.extend(
+                lines[i + 1..]
+                    .iter()
+                    .filter(|n| n.starts_with(" "))
+                    .map(|n| n.to_string()),
+            );
             let reflowed = rest.join("\n");
             let (err, line) = parse_brz_error(&reflowed, lines[..i].to_vec());
             return Some((err, line.to_string()));

--- a/src/sbuild.rs
+++ b/src/sbuild.rs
@@ -383,14 +383,13 @@ pub fn parse_sbuild_log<R: BufRead>(mut reader: R) -> impl Iterator<Item = Sbuil
                 if !lines.is_empty() {
                     // The unwrap_or_else is to provide a default value in case 'title' is None.
                     sections.push(SbuildLogSection {
-                        title: title.clone(),
+                        title: std::mem::take(&mut title),
                         offsets: (begin_offset, end_offset),
-                        lines: lines.clone(),
+                        lines: std::mem::take(&mut lines),
                     });
                 }
 
                 title = Some(l1_trimmed.trim_matches('|').trim().to_string());
-                lines.clear();
                 begin_offset = lineno;
             } else {
                 lines.push(line);
@@ -450,7 +449,10 @@ impl Serialize for SbuildFailure {
             "section",
             &self.section.as_ref().map(|s| s.title.as_deref()),
         )?;
-        state.serialize_field("origin", &self.r#match.as_ref().map(|m| m.origin().0))?;
+        state.serialize_field(
+            "origin",
+            &self.r#match.as_ref().map(|m| m.origin().as_str()),
+        )?;
         state.serialize_field(
             "lineno",
             &self


### PR DESCRIPTION
- Refactor Match trait to return &str instead of String, eliminating unnecessary allocations
- Replace clone() + clear() pattern with std::mem::take() in sbuild.rs
- Improve error handling in chatgpt.rs by replacing unwrap() with Result propagation
- Optimize iterator chains to avoid intermediate collections
- Replace manual loop with iterator methods in brz.rs
- Add Origin::as_str() accessor method for better encapsulation